### PR TITLE
Get proposal id with events

### DIFF
--- a/contracts/governance_standard/GovernorContract.sol
+++ b/contracts/governance_standard/GovernorContract.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol
 import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
 contract GovernorContract is
     Governor,

--- a/contracts/governance_standard/GovernorContract.sol
+++ b/contracts/governance_standard/GovernorContract.sol
@@ -6,7 +6,6 @@ import "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol
 import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
 contract GovernorContract is
     Governor,

--- a/scripts/governance_standard/deploy_and_run.py
+++ b/scripts/governance_standard/deploy_and_run.py
@@ -115,7 +115,7 @@ def propose(store_value):
     propose_tx.wait(2)  # We wait 2 blocks to include the voting delay
     # This will return the proposal ID, brownie.exceptions.EventLookupError will be 
     # thrown if ProposalCreated event is not emitted.
-    proposal_id = propose_tx.events['ProposalCreated']['proposalId']
+    proposal_id = propose_tx.events['ProposalCreated']['proposalId'] # you could also do `propose_tx.return_value` if your node allows
     print(f"Proposal state {GovernorContract[-1].state(proposal_id)}")
     print(
         f"Proposal snapshot {GovernorContract[-1].proposalSnapshot(proposal_id)}"

--- a/scripts/governance_standard/deploy_and_run.py
+++ b/scripts/governance_standard/deploy_and_run.py
@@ -113,15 +113,17 @@ def propose(store_value):
         tx = account.transfer(accounts[0], "0 ether")
         tx.wait(1)
     propose_tx.wait(2)  # We wait 2 blocks to include the voting delay
-    # This will return the proposal ID
-    print(f"Proposal state {GovernorContract[-1].state(propose_tx.return_value)}")
+    # This will return the proposal ID, brownie.exceptions.EventLookupError will be 
+    # thrown if ProposalCreated event is not emitted.
+    proposal_id = propose_tx.events['ProposalCreated']['proposalId']
+    print(f"Proposal state {GovernorContract[-1].state(proposal_id)}")
     print(
-        f"Proposal snapshot {GovernorContract[-1].proposalSnapshot(propose_tx.return_value)}"
+        f"Proposal snapshot {GovernorContract[-1].proposalSnapshot(proposal_id)}"
     )
     print(
-        f"Proposal deadline {GovernorContract[-1].proposalDeadline(propose_tx.return_value)}"
+        f"Proposal deadline {GovernorContract[-1].proposalDeadline(proposal_id)}"
     )
-    return propose_tx.return_value
+    return proposal_id
 
 
 # Can be done through a UI


### PR DESCRIPTION
- Get proposal id with events to avoid problems when using RPC node does not support `debug_traceTransaction`
- Import ERC20Votes in GovernorContract for build