### PR TITLE
FIX: TimelockController, operation is not ready

### DIFF
--- a/scripts/governance_standard/deploy_and_run.py
+++ b/scripts/governance_standard/deploy_and_run.py
@@ -161,7 +161,10 @@ def queue_and_execute(store_value):
         {"from": account},
     )
     tx.wait(1)
-    time.sleep(1)
+
+    if network.show_active() == 'development':
+        time.sleep(1)
+
     tx = GovernorContract[-1].execute(
         [Box[-1].address],
         [0],

--- a/scripts/governance_standard/deploy_and_run.py
+++ b/scripts/governance_standard/deploy_and_run.py
@@ -11,6 +11,7 @@ from brownie import (
     chain,
 )
 from web3 import Web3, constants
+import time
 
 # Governor Contract
 QUORUM_PERCENTAGE = 4
@@ -160,6 +161,7 @@ def queue_and_execute(store_value):
         {"from": account},
     )
     tx.wait(1)
+    time.sleep(1)
     tx = GovernorContract[-1].execute(
         [Box[-1].address],
         [0],


### PR DESCRIPTION
Hey, @PatrickAlphaC 

I've run into the same issue [as you do](https://youtu.be/rD8AxZ_wBA4?t=3110) during live of "code a dao, python version".

So far the problem reproducing when trying to use ganache local chain, which in brownie of version `1.16.4` set as `development` network with this config,
```yaml
Ganache-CLI
    id: development
    cmd: ganache-cli
    cmd_settings: {'accounts': 10, 'evm_version': 'istanbul', 'gas_limit': 12000000, 'mnemonic': 'brownie', 'port': 8545}
    host: http://127.0.0.1
```

Here's a patch which fixes timelockcontroller revert with simple delay between queue and execute trx

BTW, 
thanks for your outstanding efforts at democratization of blockchain development,

best of luck!