### PR TITLE
Update GovernanceTimeLock.sol

### DIFF
--- a/contracts/governance_standard/GovernanceTimeLock.sol
+++ b/contracts/governance_standard/GovernanceTimeLock.sol
@@ -9,7 +9,7 @@ contract GovernanceTimeLock is TimelockController {
     // executors is the list of addresses that can execute
     constructor(
         uint256 minDelay,
-        address[] memory proposers,
-        address[] memory executors
+        address[] calldata proposers,
+        address[] calldata executors
     ) TimelockController(minDelay, proposers, executors) {}
 }


### PR DESCRIPTION
Since proposers and executors don't need to be modified in the constructor, calldata is preferable and more gas efficient.